### PR TITLE
Auto install dependencies and start dev server in GitPod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tournament*.json
 yarn.lock
 /*.py
 /*.sh
+!install.sh
 *.pgn
 *.txt
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ yarn.lock
 /*.py
 /*.sh
 !install.sh
+!startserver.sh
 *.pgn
 *.txt
 *.mo

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,4 +6,4 @@ tasks:
   - name: Run MongoDb
     command: mongod
   - name: Run Server
-    command: python3 server/server.py
+    command: . startserver.sh

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,8 @@
 image:
   file: Dockerfile
 tasks:
+  - name: Install Dependencies
+    init: . install.sh
   - name: Run MongoDb
     command: mongod
   - name: Run Server

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,7 @@
 image:
   file: Dockerfile
+tasks:
+  - name: Run MongoDb
+    command: mongod
+  - name: Run Server
+    command: python3 server/server.py

--- a/README.md
+++ b/README.md
@@ -60,3 +60,14 @@ You can also set the server URI in https://gitpod.io/variables . Create a variab
 Example `LIATOMIC_URL`:
 
 `http://8080-amber-reindeer-qu3afegt.ws-eu25.gitpod.io`
+
+### Deploy to Heroku
+
+Create a Heroku app ( in the example we will assume the app name is `atomiconly` ). Then issue the following commands in Heroku CLI to set the necessary buildpacks
+
+```
+heroku buildpacks:set heroku/python --app atomiconly
+heroku buildpacks:add --index 1 heroku/nodejs --app atomiconly
+```
+
+In Heroku UI set config var `URI` to the app url without trailing slash ( `http://atomiconly.herokuapp.com` in our case ) and set `MONGO_HOST` to a MongoDb connect URI that has credentials included.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,21 @@ yarn md                                 // Compile md files to html
 ```
 python3 server/server.py
 ```
+
+## Open in GitPod
+
+GitPod lets you configure one off initializing tasks and tasks that should be run on each startup.
+
+The project comes with the necessary GitPod config files that instruct GitPod to install dependencies for the first time, and on every startup start MongoDb and the dev server.
+
+You can open the repo in GitPoe by attaching the repo url to `https://gitpod.io/#`. For this concrete fork the url would be:
+
+[https://gitpod.io/#https://github.com/easychessanimations/Liantichess](https://gitpod.io/#https://github.com/easychessanimations/Liantichess)
+
+For the first time the server won't start as the installation will be still ongoing. So wait for the installation to finish and in the `Run Server` terminal tab type `. startserver.sh` or simply bring back this command with the up arrow and now the server will start ok.
+
+You can also set the server URI in https://gitpod.io/variables, Create a variable `LIATOMIC_URI` and set it to the web page url as opened by GitPod for the server, without the trailing slash and change protocol to `http`. The startserver script will export this variable as `URI` so that redirect for oauth will be correct.
+
+Example `LIATOMIC_URL`:
+
+`http://8080-amber-reindeer-qu3afegt.ws-eu25.gitpod.io`

--- a/README.md
+++ b/README.md
@@ -43,19 +43,19 @@ yarn md                                 // Compile md files to html
 python3 server/server.py
 ```
 
-## Open in GitPod
+### Open the repo in GitPod
 
 GitPod lets you configure one off initializing tasks and tasks that should be run on each startup.
 
 The project comes with the necessary GitPod config files that instruct GitPod to install dependencies for the first time, and on every startup start MongoDb and the dev server.
 
-You can open the repo in GitPoe by attaching the repo url to `https://gitpod.io/#`. For this concrete fork the url would be:
+You can open the repo in GitPod by attaching the repo url to `https://gitpod.io/#`. For this concrete fork the url would be:
 
 [https://gitpod.io/#https://github.com/easychessanimations/Liantichess](https://gitpod.io/#https://github.com/easychessanimations/Liantichess)
 
 For the first time the server won't start as the installation will be still ongoing. So wait for the installation to finish and in the `Run Server` terminal tab type `. startserver.sh` or simply bring back this command with the up arrow and now the server will start ok.
 
-You can also set the server URI in https://gitpod.io/variables, Create a variable `LIATOMIC_URI` and set it to the web page url as opened by GitPod for the server, without the trailing slash and change protocol to `http`. The startserver script will export this variable as `URI` so that redirect for oauth will be correct.
+You can also set the server URI in https://gitpod.io/variables . Create a variable `LIATOMIC_URI` and set it to the web page url as opened by GitPod for the server, without the trailing slash and change protocol to `http`. The startserver script will export this variable as `URI` so that redirect for oauth will be correct.
 
 Example `LIATOMIC_URL`:
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,4 @@
+pip3 install -r requirements.txt --user
+yarn install
+yarn dev
+yarn md

--- a/startserver.sh
+++ b/startserver.sh
@@ -1,0 +1,3 @@
+eval $(gp env -e)
+export URI=$LIATOMIC_URI
+python3 server/server.py


### PR DESCRIPTION
GitPod lets you configure one off initializing tasks and tasks that should be run on each startup. This PR configures GitPod so that it installs dependencies for the first time, and on every startup starts MongoDb and the dev server.

For the first time the server won't start as the installation will be still ongoing. So wait for the installation to finish and in the `Run Server` terminal tab type `. startserver.sh` or simply bring back this command with the up arrow and now the server will start ok.

You can also set the server URI in https://gitpod.io/variables, Create a variable `LIATOMIC_URI` and set it to the web page url as opened by GitPod for the server, without the trailing slash and change protocol to `http`. The startserver script will export this variable as `URI` so that redirect for oauth will be correct.

Example `LIATOMIC_URL`:

`http://8080-amber-reindeer-qu3afegt.ws-eu25.gitpod.io`