### PR TITLE
Highlight check

### DIFF
--- a/client/roundCtrl.ts
+++ b/client/roundCtrl.ts
@@ -28,6 +28,15 @@ import { Clocks, MsgBoard, MsgChat, MsgCtable, MsgFullChat, MsgGameEnd, MsgGameN
 import { PyChessModel } from "./main";
 import AnalysisController from "./analysisCtrl";
 
+import { Pos } from "@publishvue/chessopsnpmts"
+
+function isCheck(fen:string){
+    const pos = Pos().setVariant("atomic").setFen(fen)
+    const check = pos.checkedKingUci() !== ""
+    console.log(fen, check)
+    return check
+}
+
 let rang = false;
 
 interface MsgUserDisconnected {
@@ -962,7 +971,7 @@ export default class RoundController {
                 this.chessground.set({
                     fen: this.fullfen,
                     turnColor: this.turnColor,
-                    check: msg.check,
+                    check: isCheck(this.fullfen),
                     lastMove: lastMove,
                 });
             }
@@ -984,7 +993,7 @@ export default class RoundController {
                             color: this.mycolor,
                             dests: this.dests,
                         },
-                        check: msg.check,
+                        check: isCheck(this.fullfen),
                         lastMove: lastMove,
                     });
 
@@ -1004,7 +1013,7 @@ export default class RoundController {
                     // giving fen here will place castling rooks to their destination in chess960 variants
                     fen: parts[0],
                     turnColor: this.turnColor,
-                    check: msg.check,
+                    check: isCheck(parts[0]),
                 });
                 if (this.clockOn && msg.status < 0) {
                     this.clocks[oppclock].start();
@@ -1037,7 +1046,7 @@ export default class RoundController {
                 color: this.spectator ? undefined : step.turnColor,
                 dests: (this.turnColor === this.mycolor && this.result === "*" && ply === this.steps.length - 1) ? this.dests : undefined,
                 },
-            check: step.check,
+            check: isCheck(step.fen),
             lastMove: move,
         });
         this.fullfen = step.fen;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Bajusz Tamás",
   "license": "AGPL-3.0",
   "dependencies": {
+    "@publishvue/chessopsnpmts": "^1.0.22",
     "chessgroundx": "^9.1.4",
     "ffish-es6": "^0.6.5",
     "gettext.js": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@publishvue/chessopsnpmts": "^1.0.22",
     "chessgroundx": "^9.1.4",
+    "child_process": "^1.0.2",
     "ffish-es6": "^0.6.5",
     "gettext.js": "^1.0.1",
     "highcharts": "^9.1.0",

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -9,7 +9,11 @@ export default {
         file: "static/pychess-variants.js",
         format: "iife",
         sourcemap: "inline",
+        globals: {
+            child_process: "childprocess",
+        },
     },
+    
     plugins: [
         nodeResolve(),
         commonjs(),

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,8 @@
 <html>
     <head>
+        <script>
+            var childprocess = {}
+        </script>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="theme-color" content="#dbd7d1"><title>{{ title }} • Liatomic</title>


### PR DESCRIPTION
This PR remedies the lack of check highlight. I don't know why the server does not send atomic check status correctly, so I used a client side chessops based module that can establish from the fen whether the king is in check and set chessground check status accordingly, If you can correct the check status in the message sent from the server, then ignore this PR. At any rate, lichess can highlight atomic checks and Liatomic should also be capable of this.