### PR TITLE
Add Discord meta

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,22 @@
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="theme-color" content="#dbd7d1"><title>{{ title }} • Liatomic</title>
+
+        <meta property="og:type" content="object" />
+        <meta property="og:site_name" content="Liatomic" />
+        <meta property="og:url" content="https://liatomic.herokuapp.com/" />
+        <meta
+            property="og:title"
+            content="Liatomic | Play Atomic and Atomic960"
+        />
+        <meta
+            property="og:description"
+            content="Play Atomic and Atomic960 at Liatomic, a chess site dedicated solely to Atomic chess."
+        />
+        <meta
+            property="og:image"
+            content=""
+        />
         <link rel="stylesheet" href={{ static("chessground.css") }}>
         <link rel="stylesheet" href={{ static("board.css") }} crossorigin="anonymous">
         <link rel="stylesheet" href={{ static("piece/standard/empty.css") }}>


### PR DESCRIPTION
Add Discord meta data to the page, so that the app link resolves nicely when posted in a Discord channel.