### PR TITLE
Make confirming draw offer optional and auto draw threefold repetition

### DIFF
--- a/client/boardSettings.ts
+++ b/client/boardSettings.ts
@@ -25,6 +25,7 @@ class BoardSettings {
     constructor() {
         this.settings = {};
         this.settings["animation"] = new AnimationSettings(this);
+        this.settings["confirmdraw"] = new ConfirmDrawSettings(this);
         this.settings["showDests"] = new ShowDestsSettings(this);
         this.settings["autoPromote"] = new AutoPromoteSettings(this);
         this.settings["arrow"] = new ArrowSettings(this);
@@ -120,6 +121,8 @@ class BoardSettings {
 
         settingsList.push(this.settings["animation"].view());
 
+        settingsList.push(this.settings["confirmdraw"].view());
+
         settingsList.push(this.settings["showDests"].view());
 
         if (variant.autoPromoteable)
@@ -204,6 +207,23 @@ class AnimationSettings extends BooleanSettings {
 
     view(): VNode {
         return h('div', checkbox(this, 'animation', _("Piece animation")));
+    }
+}
+
+class ConfirmDrawSettings extends BooleanSettings {
+    readonly boardSettings: BoardSettings;
+
+    constructor(boardSettings: BoardSettings) {
+        super('confirmdraw', true);
+        this.boardSettings = boardSettings;
+    }
+
+    update(): void {
+        
+    }
+
+    view(): VNode {
+        return h('div', checkbox(this, 'confirmdraw', _("Confirm draw offer")));
     }
 }
 

--- a/client/roundCtrl.ts
+++ b/client/roundCtrl.ts
@@ -545,7 +545,8 @@ export default class RoundController {
 
     private draw = () => {
         // console.log("Draw");
-        if (confirm(_('Are you sure you want to draw?'))) {
+        const doOfferDraw = ( localStorage.getItem("confirmdraw") === "false" ) || confirm(_('Are you sure you want to draw?')) 
+        if (doOfferDraw) {
             this.doSend({ type: "draw", gameId: this.gameId });
             this.setDialog(_("Draw offer sent"));
         }

--- a/client/roundCtrl.ts
+++ b/client/roundCtrl.ts
@@ -33,7 +33,7 @@ import { Pos } from "@publishvue/chessopsnpmts"
 function isCheck(fen:string):boolean{
     const pos = Pos().setVariant("atomic").setFen(fen)
     const check = pos.checkedKingUci() !== ""
-    console.log(fen, check)
+    //console.log(fen, check)
     return check
 }
 
@@ -1148,6 +1148,21 @@ export default class RoundController {
         return (orig: cg.Key, dest: cg.Key, capturedPiece: cg.Piece) => {
             console.log("   ground.onMove()", orig, dest, capturedPiece);
             sound.moveSound(this.variant, !!capturedPiece);
+
+            const currFen = this.steps[this.steps.length - 1].fen.split(" ").slice(0, 4).join(" ")
+
+            let fenCnt = 0
+
+            for(let i = 0;i<this.steps.length;i++){
+                if(this.steps[i].fen.split(" ").slice(0,4).join(" ") === currFen) fenCnt++
+            }
+
+            //console.log(currFen, "occured", fenCnt)
+
+            if(fenCnt >= 3){
+                console.log("requesting draw on threefold")
+                this.doSend({ type: "draw", gameId: this.gameId });
+            }
         }
     }
 


### PR DESCRIPTION
This PR introduces a setting for making draw offer confirmation optional in board settings. Being able to force a draw on repetition with one click is preferable if you are down on time. making this setting useful for bullet players.